### PR TITLE
Ordering change in Controller menu, add some visual feedback

### DIFF
--- a/ztconsole.sh
+++ b/ztconsole.sh
@@ -570,6 +570,7 @@ function networkMembers() {
     fi
     miMembers=()
     MEMSTATUS="-"
+    MEMCOUNT=0
     for i in ${arrMembers[@]}; do
         miMembers+=("$i")
 
@@ -585,6 +586,8 @@ function networkMembers() {
             ;;
         esac
         miMembers+=(" ($MEMSTATUS) ")
+        MEMCOUNT=$[ MEMCOUNT + 1 ]
+        echo -ne "\rProcessed $MEMCOUNT members..."
     done
     menuMembers=$(whiptail --title "$TITLE" --menu "Zerotier Network $NWID Member List" $WTH $WTW $[ WTH - 8 ] --cancel-button Back --ok-button Select "${miMembers[@]}" 3>&1 1>&2 2>&3)
     if [[ $? -eq 1 ]]; then
@@ -917,19 +920,20 @@ function menuNetwork() {
 }
 
 function menuNetworks() {
-    menuItems=("Create Network" "" "List Networks" "")
+    menuItems=("List Networks" "" "Create Network" "")
     menuSelect=$(whiptail --title "$TITLE" --menu "ZeroTier Networking Menu" $WTH $WTW 4 --cancel-button Back --ok-button Select "${menuItems[@]}" 3>&1 1>&2 2>&3)
     RET=$?
     if [[ $RET -eq 1 ]]; then
         menuController
     fi
     case $menuSelect in
-        "Create Network")
-            networkCreate
-        ;;
         "List Networks")
             networkList
         ;;
+        "Create Network")
+            networkCreate
+        ;;
+
     esac
 }
 

--- a/ztconsole.sh
+++ b/ztconsole.sh
@@ -589,6 +589,7 @@ function networkMembers() {
         MEMCOUNT=$[ MEMCOUNT + 1 ]
         echo -ne "\rProcessed $MEMCOUNT members..."
     done
+    echo -ne "\r"
     menuMembers=$(whiptail --title "$TITLE" --menu "Zerotier Network $NWID Member List" $WTH $WTW $[ WTH - 8 ] --cancel-button Back --ok-button Select "${miMembers[@]}" 3>&1 1>&2 2>&3)
     if [[ $? -eq 1 ]]; then
         menuNetwork $NWID


### PR DESCRIPTION
Changed order of operations in network controller menu.  (Managing existing networks is much more common than adding, so make it default).

Added visual feedback for the manage members list loading process.  On a network with a large number of members it can take several seconds for the menu to appear.